### PR TITLE
Use jinjanator instead of j2cli

### DIFF
--- a/generate-docker-compose.sh
+++ b/generate-docker-compose.sh
@@ -12,7 +12,7 @@ while read line; do
   export distro=$(echo "$line" | awk -F, '{ print $4 }')
   touch "docker-compose/docker-compose-${shortname}.yml"
   echo "Generating docker-compose-${shortname}.yml (${gamename})"
-  j2 -f env docker-compose.yml.j2 >"docker-compose/docker-compose-${shortname}.yml"
+  jinjanate docker-compose.yml.j2 >"docker-compose/docker-compose-${shortname}.yml"
   echo -n "{" >>"shortnamearray.json"
   echo -n "\"shortname\":" >>"shortnamearray.json"
   echo -n "\"${shortname}\"" >>"shortnamearray.json"

--- a/generate-dockerfiles.sh
+++ b/generate-dockerfiles.sh
@@ -12,7 +12,7 @@ while read line; do
   export distro=$(echo "$line" | awk -F, '{ print $4 }')
   touch "dockerfiles/Dockerfile.${shortname}"
   echo "Generating Dockerfile.${shortname} (${gamename})"
-  j2 -f env Dockerfile.j2 >"dockerfiles/Dockerfile.${shortname}"
+  jinjanate Dockerfile.j2 >"dockerfiles/Dockerfile.${shortname}"
   echo -n "{" >>"shortnamearray.json"
   echo -n "\"shortname\":" >>"shortnamearray.json"
   echo -n "\"${shortname}\"" >>"shortnamearray.json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-j2cli
+jinjanator


### PR DESCRIPTION
Switch to jinjanator as alternative to j2cli
for compatibility with python 3.12+.

Closes #77