### PR TITLE
updated Dockerfile and compose to include ENV crons

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -8,6 +8,12 @@ FROM gameservermanagers/linuxgsm:{{ distro }}
 LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 ARG SHORTNAME={{ shortname }}
 ENV GAMESERVER={{ shortname }}server
+# Default cron schedules (can be overridden in docker-compose)
+ENV MONITOR_CRON="*/5 * * * *"
+ENV UPDATE_CRON="*/30 * * * *"
+ENV FORCE_UPDATE_CRON="30 4 * * *"
+ENV UPDATE_LGSM_CRON="0 0 * * 0"
+ENV BACKUP_CRON="0 5 * * *"
 
 WORKDIR /app
 
@@ -16,11 +22,24 @@ RUN depshortname=$(curl --connect-timeout 10 -s https://raw.githubusercontent.co
   && if [ -n "${depshortname}" ]; then \
   echo "**** Install ${depshortname} ****" \
   && apt-get update \
-  && apt-get install -y ${depshortname} \
+  && apt-get install -y ${depshortname} cron \
   && apt-get -y autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
   fi
+
+# Set up cron jobs dynamically based on environment variables
+RUN echo "Setting up cron jobs" \
+&& echo "$MONITOR_CRON /app/$GAMESERVER monitor > /dev/null 2>&1" >> /etc/crontab \
+&& echo "$UPDATE_CRON /app/$GAMESERVER update > /dev/null 2>&1" >> /etc/crontab \
+&& echo "$FORCE_UPDATE_CRON /app/$GAMESERVER force-update > /dev/null 2>&1" >> /etc/crontab \
+&& echo "$UPDATE_LGSM_CRON /app/$GAMESERVER update-lgsm > /dev/null 2>&1" >> /etc/crontab \
+&& echo "$BACKUP_CRON /app/$GAMESERVER backup > /dev/null 2>&1" >> /etc/crontab \
+&& chmod 0644 /etc/crontab \
+&& crontab /etc/crontab
+
+# Run cron in the background
+RUN service cron start
 
 HEALTHCHECK --interval=1m --timeout=1m --start-period=2m --retries=1 CMD /app/entrypoint-healthcheck.sh || exit 1
 

--- a/docker-compose.yml.j2
+++ b/docker-compose.yml.j2
@@ -5,6 +5,13 @@ services:
     image: gameservermanagers/gameserver:{{ shortname }}
     # image: ghcr.io/gameservermanagers/gameserver:{{ shortname }}
     container_name: {{ shortname }}server
+    environment:
+    # Cron job environment variables
+      MONITOR_CRON: "*/5 * * * *"
+      UPDATE_CRON: "*/30 * * * *"
+      FORCE_UPDATE_CRON: "30 4 * * *"
+      UPDATE_LGSM_CRON: "0 0 * * 0"
+      BACKUP_CRON: "0 5 * * *"
     restart: unless-stopped
     volumes:
       - /path/to/linuxgsm/{{ shortname }}server:/data
@@ -15,6 +22,13 @@ services:
     image: gameservermanagers/gameserver:{{ shortname }}
     # image: ghcr.io/gameservermanagers/gameserver:{{ shortname }}
     container_name: {{ shortname }}server
+    environment:
+    # Cron job environment variables
+      MONITOR_CRON: "*/5 * * * *"
+      UPDATE_CRON: "*/30 * * * *"
+      FORCE_UPDATE_CRON: "30 4 * * *"
+      UPDATE_LGSM_CRON: "0 0 * * 0"
+      BACKUP_CRON: "0 5 * * *"
     restart: unless-stopped
     volumes:
       - linuxgsm-{{ shortname }}:/data


### PR DESCRIPTION
I added Environment variables to set cronjobs for updating and backing up servers, I pulled the cron examples from documentation here https://docs.linuxgsm.com/configuration/cronjobs and here https://docs.linuxgsm.com/commands/backup

this seems to work just fine with Palworld but will likely require further testing. 